### PR TITLE
chore: upgrade all dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-derive_builder = "0.12.0"
-fancy-regex = "0.11.0"
-lazy_static = "1.4.0"
-thiserror = "1.0.38"
-url = "2.3.1"
-urlencoding = "2.1.2"
+anyhow = "1"
+derive_builder = "0.20"
+fancy-regex = "0.16"
+lazy_static = "1"
+thiserror = "2"
+url = "2"
+urlencoding = "2"
 
 [dev-dependencies]
-rstest = "0.16.0"
+rstest = "0.26"


### PR DESCRIPTION
Upgrade to latest major versions:
- derive_builder 0.12 → 0.20
- fancy-regex 0.11 → 0.16
- rstest 0.16 → 0.26
- thiserror 1 → 2